### PR TITLE
feat: Cookie の有効期限が短すぎたので延長する

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,8 +16,11 @@ export default () => {
   const [, setCookie] = useCookies([]);
 
   useEffect(() => {
-    setCookie('noSpecifyDomainCookie', '111', {maxAge: 20});
-    setCookie('specifyDomainCookie', '222', {maxAge: 20, domain: 'numb86.net'});
+    setCookie('noSpecifyDomainCookie', '111', {maxAge: 180});
+    setCookie('specifyDomainCookie', '222', {
+      maxAge: 180,
+      domain: 'numb86.net',
+    });
   }, []);
 
   return (


### PR DESCRIPTION
用が終わったらすぐに消すべきものとはいえ`20`秒は短すぎたので、`180`秒にした。